### PR TITLE
Add release action and update csproj to remove automatic post build script.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: .NET Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+    #this makes it not run if tests failed.
+    #needs: test
+    steps:
+    - uses: actions/checkout@v4
+      with:
+           ref: ${{ github.event.release.tag_name }}
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Set envars for versions
+      run: | 
+        TAG=${{ github.event.release.tag_name }}
+        VERSION=${TAG#v}
+        echo Version: $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "SHORT_VERSION=${VERSION%-*}" >> $GITHUB_ENV
+      shell: bash
+    - name: Build X64
+      run: dotnet publish .\DS4Windows\DS4WinWPF.csproj -c Release  /p:platform=x64 /p:AssemblyVersion=${{ env.SHORT_VERSION }} /p:FileVersion=${{ env.SHORT_VERSION }} /p:Version=${{ env.VERSION }} -o .\bin\x64\Release\output
+    - name: Post-Build script X64
+      run: python .\utils\post-build.py .\bin\x64\Release\output . ${{env.VERSION}}
+    - name: Publish release Build X64
+      run: gh release upload ${{github.event.release.tag_name}} .\bin\x64\Release\DS4Windows_${{env.VERSION}}_x64.zip
+      env:
+        GITHUB_TOKEN: ${{ github.TOKEN }}
+    - name: Build X86
+      run: dotnet publish .\DS4Windows\DS4WinWPF.csproj -c Release  /p:platform=x86 /p:AssemblyVersion=${{ env.SHORT_VERSION }} /p:FileVersion=${{ env.SHORT_VERSION }} /p:Version=${{ env.VERSION }} -o .\bin\x86\Release\output
+    - name: Post-Build script X86
+      run: python .\utils\post-build.py .\bin\x86\Release\output . ${{env.VERSION}}
+    - name: Publish release Build X86
+      run: gh release upload ${{github.event.release.tag_name}} .\bin\x86\Release\DS4Windows_${{env.VERSION}}_x86.zip
+      env:
+        GITHUB_TOKEN: ${{ github.TOKEN }}

--- a/DS4Windows/ApiDtos/GitHubRelease.cs
+++ b/DS4Windows/ApiDtos/GitHubRelease.cs
@@ -1,0 +1,6 @@
+﻿namespace DS4WinWPF.ApiDtos
+{
+    // Check this linkg for the avalaible options 
+    // https://api.github.com/repos/schmaldeo/DS4Windows/releases/latest
+    public record GitHubRelease(string tag_name);
+}

--- a/DS4Windows/App.xaml.cs
+++ b/DS4Windows/App.xaml.cs
@@ -16,15 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+using NLog;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.MemoryMappedFiles;
-using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -32,12 +30,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
-using WPFLocalizeExtension.Engine;
-using NLog;
 using System.Windows.Media;
-using System.Net;
-using Microsoft.Win32.SafeHandles;
-using DS4Windows.DS4Control;
+using WPFLocalizeExtension.Engine;
 
 namespace DS4WinWPF
 {
@@ -484,11 +478,13 @@ namespace DS4WinWPF
 
         private void CreateControlService(ArgumentParser parser)
         {
-            controlThread = new Thread(() => {
+            controlThread = new Thread(() =>
+            {
                 rootHub = new DS4Windows.ControlService(parser);
 
                 DS4Windows.Program.rootHub = rootHub;
                 requestClient = new HttpClient();
+                requestClient.DefaultRequestHeaders.Add("User-Agent", "DS4Windows");
                 collectTimer = new Timer(GarbageTask, null, 30000, 30000);
 
             });
@@ -501,9 +497,11 @@ namespace DS4WinWPF
 
         private void CreateBaseThread()
         {
-            controlThread = new Thread(() => {
+            controlThread = new Thread(() =>
+            {
                 DS4Windows.Program.rootHub = rootHub;
                 requestClient = new HttpClient();
+                requestClient.DefaultRequestHeaders.Add("User-Agent", "DS4Windows");
                 collectTimer = new Timer(GarbageTask, null, 30000, 30000);
             });
             controlThread.Priority = ThreadPriority.Normal;
@@ -650,7 +648,7 @@ namespace DS4WinWPF
             MemoryMappedFile mmf = null;
             MemoryMappedViewAccessor mma = null;
             EventWaitHandle ipcNotifyEvent = null;
-          
+
             try
             {
                 ipcNotifyEvent = EventWaitHandle.OpenExisting("DS4Windows_IPCResultData_ReadyEvent");
@@ -692,7 +690,7 @@ namespace DS4WinWPF
         }
 
         public void ChangeTheme(DS4Windows.AppThemeChoice themeChoice,
-            bool fireChanged=true)
+            bool fireChanged = true)
         {
             if (themeChoice == DS4Windows.AppThemeChoice.Default)
             {

--- a/DS4Windows/DS4WinWPF.csproj
+++ b/DS4Windows/DS4WinWPF.csproj
@@ -15,9 +15,9 @@
 		<RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
 		<EnableNETAnalyzers>false</EnableNETAnalyzers>
 		<ServerGarbageCollection>true</ServerGarbageCollection>
-		<AssemblyVersion>3.7.2</AssemblyVersion>
-		<FileVersion>3.7.2</FileVersion>
-		<Version>3.7.2</Version>
+		<AssemblyVersion>0.0.0</AssemblyVersion>
+		<FileVersion>0.0.0</FileVersion>
+		<Version>0.0.0</Version>
 		<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
 		<Platform Condition=" '$(Platform)' == '' ">x64</Platform>
 		<Copyright>Copyright © Scarlet.Crush Productions 2012, 2013; InhexSTER, HecticSeptic, electrobrains 2013, 2014; Jays2Kings 2013, 2014, 2015, 2016; Ryochan7 2017-2023, schmaldeo 2024</Copyright>
@@ -375,7 +375,4 @@
 	<ItemGroup>
 		<Folder Remove="extras\" />
 	</ItemGroup>
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Release'">
-    <Exec Command="python $(SolutionDir)utils\post-build.py $(TargetDir) $(ProjectDir) $(Version)" />
-  </Target>
 </Project>


### PR DESCRIPTION
Change version check behaviour to use Github API. This way it's not necessary to maintain newest.txt.

Did not remove the file because of background compatibility.