### PR TITLE
Reworked native calls

### DIFF
--- a/DS4Windows/NativeMethods.txt
+++ b/DS4Windows/NativeMethods.txt
@@ -1,4 +1,9 @@
-﻿ReadFile
+﻿CreateFile
+ReadFile
 CreateEvent
 WaitForSingleObject
 GetOverlappedResult
+FILE_CREATION_DISPOSITION
+FILE_FLAGS_AND_ATTRIBUTES
+FILE_ACCESS_RIGHTS
+FILE_SHARE_MODE


### PR DESCRIPTION
Continuation of discussion in #15 

## Changes

- Ported a few more types to `CsWin32`
- Decorated some types with `Obsolete`
- Removed some flags from `CreateFile` call that don't do anything for HID devices to begin with