### PR TITLE
Add support for Nacon Revolution 5 Pro

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -185,8 +185,8 @@ namespace DS4Windows
             new VidPidInfo(0x044F, 0xD00E, "Thrustmaster eSwap Pro", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.NoBatteryReading), // Thrustmaster eSwap Pro (wired only. No lightbar or gyro)
             new VidPidInfo(0x054C, 0x0268, "DualShock 3 (SXS)", InputDeviceType.DS3, VidPidFeatureSet.DefaultDS4, checkConnection: DS3Device.DetermineConnectionType), // Sony DualShock 3 using DsHidMini driver (SXS) or Sony Sixaxis driver
             new VidPidInfo(0x0C12, 0x0E15, "Playmax Wired Controller (PS4)", InputDeviceType.DS4, VidPidFeatureSet.NoBatteryReading | VidPidFeatureSet.NoGyroCalib), // Generic PS4 Controller by Playmax (brand primarily in New Zealand). Standard Wired PS4 controller, no Gyro, no Lightbar, no Battery. There is a newer model but I'm not sure if it uses a different Vid or Pid yet.
-            new VidPidInfo(0x3285, 0x0D17, "Nacon Revol 5 Pro Wired (PS4 Mode)", InputDeviceType.DS4, VidPidFeatureSet.NoBatteryReading), // Nacon Revolution 5 Pro (PS4 mode) connected via cable
             new VidPidInfo(0x3285, 0x0D16, "Nacon Revol 5 Pro Wireless (PS4 Mode)", InputDeviceType.DS4, VidPidFeatureSet.NoBatteryReading), // Nacon Revolution 5 Pro (PS4 mode) connected via its wireless adapter
+            new VidPidInfo(0x3285, 0x0D17, "Nacon Revol 5 Pro Wired (PS4 Mode)", InputDeviceType.DS4, VidPidFeatureSet.NoBatteryReading), // Nacon Revolution 5 Pro (PS4 mode) connected via cable
             new VidPidInfo(0x3285, 0x0D18, "Nacon Revol 5 Pro Wireless (PS5 Mode)", InputDeviceType.DS4, VidPidFeatureSet.NoBatteryReading), // Nacon Revolution 5 Pro (PS5 mode) connected via its wireless adapter
             new VidPidInfo(0x3285, 0x0D19, "Nacon Revol 5 Pro Wired (PS5 Mode)", InputDeviceType.DS4, VidPidFeatureSet.NoBatteryReading), // Nacon Revolution 5 Pro (PS5 mode) connected via cable
 


### PR DESCRIPTION
- Controller has different VID/PID depending on both connection type (Cable vs Wireless adapter) as well as "Mode" (PS5, PS4, PC)
    - ~~Only the "PS4 Mode USB" and "PS4 Mode Wireless" VID/PID were added since I don't see any reason to add the VID/PID for PS5 mode~~ Added wired and wireless PS5 modes because "why not?"
- Controller does not report its battery, NoBatteryReading flag was enabled
- Apparently gyro calibration works? 
    - I don't know how to properly test it but I asked the user who has the controller to try the gyro callibration button in the profile editor and see if the "gree sphere" would blink for a few seconds and then stop. They did that and it worked as normal, no error messages, nothing exploded, so I hope it's ok
- ~~Lightbar~~, rumble and touchpad work as expected
    - Lightbar does not work properly in wireless DS4 Mode, requiring the "copycat" device option to be enabled so DS4Windows stops sending "flash" commands