### PR TITLE
Fix touchpad clicks and cursor movement in Passthru mode when switching profiles

### DIFF
--- a/DS4Windows/DS4Control/Mouse.cs
+++ b/DS4Windows/DS4Control/Mouse.cs
@@ -44,6 +44,7 @@ namespace DS4Windows
         public bool priorLeftDown, priorRightDown, priorUpperDown, priorMultiDown;
         private bool touchStarted = false;
         private bool touchEnded = false;
+        private bool touchStartedInPassthru = false;
         protected DS4Controls pushed = DS4Controls.None;
         protected Mapping.Click clicked = Mapping.Click.None;
         public int CursorGyroDead { get => cursor.GyroCursorDeadZone; set => cursor.GyroCursorDeadZone = value; }
@@ -1103,7 +1104,7 @@ namespace DS4Windows
             TouchpadOutMode tempMode = Global.TouchOutMode[deviceNum];
             if (tempMode == TouchpadOutMode.Mouse)
             {
-                if (Global.GetTouchActive(deviceNum))
+                if (Global.GetTouchActive(deviceNum) && !touchStartedInPassthru)
                 {
                     int[] disArray = Global.getTouchDisInvertTriggers(deviceNum);
                     tempBool = true;
@@ -1157,7 +1158,7 @@ namespace DS4Windows
             }
             else if (tempMode == TouchpadOutMode.AbsoluteMouse)
             {
-                if (Global.GetTouchActive(deviceNum))
+                if (Global.GetTouchActive(deviceNum) && !touchStartedInPassthru)
                 {
                     cursor.TouchesMovedAbsolute(arg);
                 }
@@ -1658,6 +1659,7 @@ namespace DS4Windows
         private void TouchButtonUpFlags()
         {
             upperDown = leftDown = rightDown = multiDown = false;
+            touchStartedInPassthru = false;
             touchButtonCurrentCandidate = TouchButtonModeCandidate.None;
         }
 
@@ -1777,6 +1779,11 @@ namespace DS4Windows
 
             if (activateTouchButton)
             {
+                if (Global.TouchOutMode[deviceNum] == TouchpadOutMode.Passthru)
+                {
+                    touchStartedInPassthru = true;
+                }
+
                 switch (touchButtonCurrentCandidate)
                 {
                     case TouchButtonModeCandidate.Left:
@@ -1816,7 +1823,7 @@ namespace DS4Windows
             }
 
             if (Global.GetDS4CSetting(deviceNum, DS4Controls.TouchLeft).IsDefault &&
-                leftDown)
+                leftDown && !touchStartedInPassthru)
             {
                 Mapping.MapClick(deviceNum, Mapping.Click.Left);
                 dragging2 = true;


### PR DESCRIPTION
Fixes this issue: https://github.com/schmaldeo/DS4Windows/issues/87

## Problem
When using a DualSense controller in Passthru touchpad mode, if the user switches profiles with touchpad, the touch state flags persist across the profile change. This causes unwanted mouse clicks and cursor movement to be generated when the profile switches to a mode that uses mouse simulation.

## Root Cause
The `leftDown` touch flag is set when the touch begins in Passthru mode. When a profile switch occurs during the touch, the new profile's touchpad mode processes the ongoing touch event. Since `synthesizeMouseButtons()` only checks the *current* mode (`touchpadOutputMode == TouchpadOutMode.Passthru`), it doesn't know the touch originated in Passthru mode and generates a click.

## Solution
Added a `touchStartedInPassthru` flag to track the touchpad mode when a touch **begins**. This flag:
- Is set to `true` when touch activates in Passthru mode
- Persists across profile switches during the touch
- Prevents click generation and cursor movement in `synthesizeMouseButtons()` and `touchesMoved()`
- Is reset when the touch ends in `TouchButtonUpFlags()`

This preserves the original intent: touches that start in Passthru mode should never generate mouse simulation, regardless of profile changes.

## Changes
- **File Modified:** `DS4Windows/DS4Control/Mouse.cs`
  - Added `touchStartedInPassthru` field declaration (~line 47)
  - Modified `TouchButtonUpFlags()` to reset flag on touch end (~line 1661)
  - Modified `TouchButtonCheckProcess()` to set flag when touch activates in Passthru mode (~line 1782)
  - Modified `synthesizeMouseButtons()` to prevent clicks when flag is set (~line 1826)
  - Modified `touchesMoved()` Mouse mode section to prevent cursor movement when flag is set (~line 1107)
  - Modified `touchesMoved()` AbsoluteMouse mode section to prevent cursor movement when flag is set (~line 1161)

## Testing
- Touch detection still works for hotkeys (touch flags are set correctly)
- No clicks generated when touch starts in Passthru mode and profile switches
- No cursor movement when touch starts in Passthru mode and profile switches
- Normal clicking and cursor movement in non-Passthru modes unaffected
- Profile switching during touch works correctly in all modes
